### PR TITLE
Refactored out sqlite

### DIFF
--- a/closurizer/closurizer.py
+++ b/closurizer/closurizer.py
@@ -1,13 +1,19 @@
 from typing import List
 
 import petl as etl
-import sqlite3
 import os
 import tarfile
 
 
 def _string_agg(key, rows):
     return [key, "|".join(row[1] for row in rows)]
+
+
+def _cut_left_join(ltable, rtable, field, attribute):
+    return etl.leftjoin(ltable,
+                        (etl.cut(rtable, ['id', attribute]).rename(attribute, f"{field}_{attribute}")),
+                        lkey=field,
+                        rkey="id")
 
 
 def add_closure(node_file: str,
@@ -17,7 +23,6 @@ def add_closure(node_file: str,
                 path: str,
                 fields: List[str],
                 output_file: str):
-
     print("Generating closure KG...")
     print(f"node_file: {node_file}")
     print(f"edge_file: {edge_file}")
@@ -34,35 +39,28 @@ def add_closure(node_file: str,
     node_file = f"{path}/{node_file}"
     edge_file = f"{path}/{edge_file}"
 
-    db = "closurizer.db"
-
-    if os.path.exists(db):
-        os.remove(db)
-    sqlite = sqlite3.connect(db)
-
     nodes = etl.fromtsv(node_file)
-    etl.todb(nodes, sqlite, "nodes", create=True)
+    nodes = etl.addfield(nodes, 'namespace', lambda rec: rec['id'][:rec['id'].index(":")])
 
     edges = etl.fromtsv(edge_file)
 
-    for field in fields:
-        edges = etl.addfield(edges, f"{field}_namespace")
-        edges = etl.addfield(edges, f"{field}_category")
-        edges = etl.addfield(edges, f"{field}_closure")
-        edges = etl.addfield(edges, f"{field}_label")
-        edges = etl.addfield(edges, f"{field}_closure_label")
-
-    etl.todb(edges, sqlite, "edges", create=True)
-
+    # Load the relation graph tsv in long format mapping a node to each of it's ancestors
     closure_table = (etl
                      .fromtsv(closure_file)
                      .setheader(['id', 'predicate', 'ancestor'])
                      .cutout('predicate')  # assume all predicates for now
                      )
+    print("closure table")
+    print(etl.head(closure_table))
+    # Prepare the closure id table, mapping node IDs to pipe separated lists of ancestors
+    closure_id_table = (etl.rowreduce(closure_table, key='id',
+                                      reducer=_string_agg,
+                                      header=['id', 'ancestors'])
+                        .rename('ancestors', 'closure'))
+    print("closure_id_table")
+    print(etl.head(closure_id_table))
 
-    closure_id_table = etl.rowreduce(closure_table, key='id', reducer=_string_agg, header=['id', 'ancestors'])
-    etl.todb(closure_id_table, sqlite, "closure", create=True)
-
+    # Prepare the closure label table, mapping node IDs to pipe separated lists of ancestor names
     closure_label_table = (etl.leftjoin(closure_table,
                                         etl.cut(nodes, ["id", "name"]),
                                         lkey="ancestor",
@@ -70,56 +68,23 @@ def add_closure(node_file: str,
                            .cutout("ancestor")
                            .rename("name", "closure_label")
                            .selectnotnone("closure_label")
-                           .rowreduce(key='id', reducer=_string_agg, header=['id', 'ancestor_labels']))
-    etl.todb(closure_label_table, sqlite, "closure_label", create=True)
-
-    cur = sqlite.cursor()
-
-    for field in fields:
-        etl.leftjoin(edges, closure_id_table, lkey=f"{field}", rkey="id")
+                           .rowreduce(key='id', reducer=_string_agg, header=['id', 'ancestor_labels'])
+                           .rename('ancestor_labels', 'closure_label'))
+    print("closure_label_table")
+    print(etl.head(closure_label_table))
 
     for field in fields:
+        edges = _cut_left_join(edges, nodes, field, "namespace")
+        edges = _cut_left_join(edges, nodes, field, "category")
+        edges = _cut_left_join(edges, closure_id_table, field, "closure")
+        edges = _cut_left_join(edges, closure_label_table, field, "closure_label")
+        edges = etl.leftjoin(edges, (etl.cut(nodes, ["id", "name"]).rename("name", f"{field}_label")), lkey=field,
+                             rkey="id")
 
-        cur.execute(f"""
-        update edges 
-        set {field}_namespace = SUBSTR(nodes.id,1,INSTR(nodes.id,':') -1)
-        from nodes
-        where edges.{field} = nodes.id;
-        """)
+    print("edges table")
+    print(etl.head(edges))
 
-        cur.execute(f"""
-        update edges 
-        set {field}_category = nodes.category
-        from nodes
-        where edges.{field} = nodes.id;
-        """)
-
-        cur.execute(f"""
-        update edges
-        set {field}_closure = ancestors 
-        from closure
-        where edges.{field} = closure.id;
-        """)
-
-        cur.execute(f"""
-        update edges 
-        set {field}_label = nodes.name
-        from nodes
-        where edges.{field} = nodes.id;
-        """)
-
-        cur.execute(f"""
-        update edges
-        set {field}_closure_label = closure_label.ancestor_labels
-        from closure_label
-        where edges.{field} = closure_label.id;
-        """)
-
-    etl.fromdb(sqlite, 'select * from edges').totsv(f"{path}/{output_file}")
-
-    # Clean up the database
-    if os.path.exists(db):
-        os.remove(db)
+    etl.totsv(edges, f"{path}/{output_file}")
 
     # Clean up extracted node & edge files
     if os.path.exists(f"{path}/{node_file}"):

--- a/poetry.lock
+++ b/poetry.lock
@@ -53,6 +53,14 @@ xlsx = ["openpyxl (>=2.6.2)"]
 xpath = ["lxml (>=4.4.0)"]
 
 [[package]]
+name = "pysqlite3-binary"
+version = "0.4.7.post7"
+description = "DB-API 2.0 interface for Sqlite 3.x"
+category = "main"
+optional = false
+python-versions = "*"
+
+[[package]]
 name = "sqlalchemy"
 version = "1.4.37"
 description = "Database Abstraction Library"
@@ -84,27 +92,10 @@ postgresql_psycopg2cffi = ["psycopg2cffi"]
 pymysql = ["pymysql (<1)", "pymysql"]
 sqlcipher = ["sqlcipher3-binary"]
 
-[[package]]
-name = "typer"
-version = "0.4.1"
-description = "Typer, build great CLIs. Easy to code. Based on Python type hints."
-category = "main"
-optional = false
-python-versions = ">=3.6"
-
-[package.dependencies]
-click = ">=7.1.1,<9.0.0"
-
-[package.extras]
-all = ["colorama (>=0.4.3,<0.5.0)", "shellingham (>=1.3.0,<2.0.0)"]
-dev = ["autoflake (>=1.3.1,<2.0.0)", "flake8 (>=3.8.3,<4.0.0)"]
-doc = ["mkdocs (>=1.1.2,<2.0.0)", "mkdocs-material (>=8.1.4,<9.0.0)", "mdx-include (>=1.4.1,<2.0.0)"]
-test = ["shellingham (>=1.3.0,<2.0.0)", "pytest (>=4.4.0,<5.4.0)", "pytest-cov (>=2.10.0,<3.0.0)", "coverage (>=5.2,<6.0)", "pytest-xdist (>=1.32.0,<2.0.0)", "pytest-sugar (>=0.9.4,<0.10.0)", "mypy (==0.910)", "black (>=22.3.0,<23.0.0)", "isort (>=5.0.6,<6.0.0)"]
-
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.8"
-content-hash = "50060932af2b7e5a0ed4e78cc4d06e42dddd4a23878b4471c8b6844eca49aadc"
+content-hash = "a5cd07e9b071eaf97657371f2132a6c3a2faea51cb01dcd6ed563ce49fbc3898"
 
 [metadata.files]
 click = [
@@ -175,6 +166,7 @@ greenlet = [
 petl = [
     {file = "petl-1.7.10.tar.gz", hash = "sha256:713407e5922edea565d180042bdb4e17961a2cb028bd24edac5518eab6a165df"},
 ]
+pysqlite3-binary = []
 sqlalchemy = [
     {file = "SQLAlchemy-1.4.37-cp27-cp27m-macosx_10_14_x86_64.whl", hash = "sha256:d9050b0c4a7f5538650c74aaba5c80cd64450e41c206f43ea6d194ae6d060ff9"},
     {file = "SQLAlchemy-1.4.37-cp27-cp27m-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:b4c92823889cf9846b972ee6db30c0e3a92c0ddfc76c6060a6cda467aa5fb694"},
@@ -211,8 +203,4 @@ sqlalchemy = [
     {file = "SQLAlchemy-1.4.37-cp39-cp39-win32.whl", hash = "sha256:5e4e517ce72fad35cce364a01aff165f524449e9c959f1837dc71088afa2824c"},
     {file = "SQLAlchemy-1.4.37-cp39-cp39-win_amd64.whl", hash = "sha256:c37885f83b59e248bebe2b35beabfbea398cb40960cdc6d3a76eac863d4e1938"},
     {file = "SQLAlchemy-1.4.37.tar.gz", hash = "sha256:3688f92c62db6c5df268e2264891078f17ecb91e3141b400f2e28d0f75796dea"},
-]
-typer = [
-    {file = "typer-0.4.1-py3-none-any.whl", hash = "sha256:e8467f0ebac0c81366c2168d6ad9f888efdfb6d4e1d3d5b4a004f46fa444b5c3"},
-    {file = "typer-0.4.1.tar.gz", hash = "sha256:5646aef0d936b2c761a10393f0384ee6b5c7fe0bb3e5cd710b17134ca1d99cff"},
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "closurizer"
-version = "0.1.4"
+version = "0.1.6"
 description = "Add closure expansion fields to kgx files following the Golr pattern"
 authors = ["Kevin Schaper <kevin@tislab.org>"]
 


### PR DESCRIPTION
On my laptop, I was able to use SUBSTR functions in sqlite to pull the namespace out of a curie, but our ubuntu servers the sqlite version wasn't new enough to support that. We could definitely update our infrastructure, but I found it a little unnerving that it was a version requirement that we couldn't specify in poetry. It was also a little strange that some of the joins were done in petl before and some with sqlite - maybe better to say that it just felt arbitrary. 