### PR TITLE
Add support for populating a grouping_key column

### DIFF
--- a/closurizer/cli.py
+++ b/closurizer/cli.py
@@ -8,11 +8,13 @@ from closurizer.closurizer import add_closure
 @click.option('--closure', required=True, help='TSV file of closure triples')
 @click.option('--output', '-o', required=True, help='file write kgx file with closure fields added')
 @click.option('--fields', multiple=True, help='fields to closurize')
+@click.option('--grouping-fields', multiple=True, help='fields to concantenate in a grouping_key field')
 def main(kg: str,
          closure: str,
          output: str,
-         fields: List[str] = None):
-    add_closure(kg_archive=kg, closure_file=closure, fields=fields, output_file=output)
+         fields: List[str] = None,
+         grouping_fields: List[str] = None):
+    add_closure(kg_archive=kg, closure_file=closure, fields=fields, output_file=output, grouping_fields=grouping_fields)
 
 
 if __name__ == "__main__":

--- a/closurizer/closurizer.py
+++ b/closurizer/closurizer.py
@@ -71,7 +71,7 @@ def add_closure(kg_archive: str,
     edges = etl.fromtsv(edge_file)
 
     if grouping_fields is not None and len(grouping_fields) > 0:
-        edges["grouping_key"] = edges.addfield("grouping_key", lambda rec: "|".join([rec[field] for field in grouping_fields]))
+        edges = etl.addfield(edges,"grouping_key", lambda rec: "|".join([rec[field] for field in grouping_fields]))
 
     # Load the relation graph tsv in long format mapping a node to each of it's ancestors
     closure_table = (etl


### PR DESCRIPTION
We want to experiment with using Solr result grouping to 'fake' edge merging, so this PR allows for a list of fields to be passed in, and their values will be concatenated to make a grouping key string that will be stored in a single value field