### PR TITLE
Keep lists in duckdb for edge closure lists, but export to tsv with pipes

### DIFF
--- a/closurizer/closurizer.py
+++ b/closurizer/closurizer.py
@@ -172,7 +172,7 @@ def add_closure(kg_archive: str,
 
         edges_export_query = f"""
         -- write denormalized_edges as tsv
-        copy (select *, {edge_closure_replacements} from denormalized_edges) to '{edges_output_file}' (header, delimiter '\t')
+        copy (select * {edge_closure_replacements} from denormalized_edges) to '{edges_output_file}' (header, delimiter '\t')
         """
         print(edges_export_query)
         db.query(edges_export_query)

--- a/closurizer/closurizer.py
+++ b/closurizer/closurizer.py
@@ -162,8 +162,8 @@ def add_closure(kg_archive: str,
 
         edge_closure_replacements = [
             f"""
-            list_aggregate({field}_closure.closure, 'string_agg', '|') as {field}_closure,
-            list_aggregate({field}_closure_label.closure_label, 'string_agg', '|') as {field}_closure_label
+            list_aggregate({field}_closure, 'string_agg', '|') as {field}_closure,
+            list_aggregate({field}_closure_label, 'string_agg', '|') as {field}_closure_label
             """
             for field in edge_fields
         ]

--- a/closurizer/closurizer.py
+++ b/closurizer/closurizer.py
@@ -156,27 +156,32 @@ def add_closure(kg_archive: str,
     """
     print(nodes_query)
 
-    edge_closure_replacements = [
-        f"""
-        list_aggregate({field}_closure.closure, 'string_agg', '|') as {field}_closure,
-        list_aggregate({field}_closure_label.closure_label, 'string_agg', '|') as {field}_closure_label
-        """
-        for field in edge_fields
-    ]
-
-    edge_closure_replacements = "REPLACE (\n" + ",\n".join(edge_closure_replacements) + ")\n"
 
     if not dry_run:
-        db.query(edges_query)
-        db.query(f"""
+
+
+        edge_closure_replacements = [
+            f"""
+            list_aggregate({field}_closure.closure, 'string_agg', '|') as {field}_closure,
+            list_aggregate({field}_closure_label.closure_label, 'string_agg', '|') as {field}_closure_label
+            """
+            for field in edge_fields
+        ]
+
+        edge_closure_replacements = "REPLACE (\n" + ",\n".join(edge_closure_replacements) + ")\n"
+
+        edges_export_query = f"""
         -- write denormalized_edges as tsv
         copy (select *, {edge_closure_replacements} from denormalized_edges) to '{edges_output_file}' (header, delimiter '\t')
-        """)
-        db.query(nodes_query)
-        db.query(f"""
+        """
+        print(edges_export_query)
+        db.query(edges_export_query)
+
+        nodes_export_query = f"""
         -- write denormalized_nodes as tsv
         copy (select * from denormalized_nodes) to '{nodes_output_file}' (header, delimiter '\t')
-        """)
+        """
+        print(nodes_export_query)
 
 
         # Clean up extracted node & edge files

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "closurizer"
-version = "0.7.1"
+version = "0.7.2"
 description = "Add closure expansion fields to kgx files following the Golr pattern"
 authors = ["Kevin Schaper <kevin@tislab.org>"]
 


### PR DESCRIPTION
- **keep closures as lists in the db, export them pipe separated in the tsv**
- **print the export queries**
- **fix sql replace syntax**
- **fix sql replace syntax**
